### PR TITLE
Fix shorthand notation for stubbing

### DIFF
--- a/docs/5-stubbing-results.md
+++ b/docs/5-stubbing-results.md
@@ -71,7 +71,7 @@ td.when(woof()).thenReturn('bark')
 Is equivalent to this:
 
 ``` javascript
-var woof = td.when(td.function()).thenReturn('bark')
+var woof = td.when(td.function()()).thenReturn('bark')
 ```
 
 ### Stubbing sequential return values


### PR DESCRIPTION
Inline test double should be executed in order to stub the invocation.